### PR TITLE
accept uint256 in public functions

### DIFF
--- a/src/NFTAdapter.sol
+++ b/src/NFTAdapter.sol
@@ -49,7 +49,7 @@ contract NFTAdapter is DSNote {
     bytes12 public kin;
     GemLike public gem;
 
-    int256 constant ONE = 10 ** 45;
+    int256 constant ONE = 10 ** 45; // rad
 
     constructor(address vat_, bytes12 kin_, address gem_) public {
         vat = VatLike(vat_);

--- a/src/NFTAdapter.sol
+++ b/src/NFTAdapter.sol
@@ -49,8 +49,7 @@ contract NFTAdapter is DSNote {
     bytes12 public kin;
     GemLike public gem;
 
-    int256  constant ONE = 10 ** 45;
-    uint160 constant MAX_UINT160 = 2^160 - 1;
+    int256 constant ONE = 10 ** 45;
 
     constructor(address vat_, bytes12 kin_, address gem_) public {
         vat = VatLike(vat_);
@@ -59,23 +58,24 @@ contract NFTAdapter is DSNote {
     }
 
     function join(bytes32 urn, uint256 obj) external note {
-        require(obj <= MAX_UINT160);
+        require(uint256(uint160(obj)) == obj);
         require(bytes20(urn) == bytes20(msg.sender));
 
         gem.transferFrom(msg.sender, address(this), obj);
-        vat.slip(ilkName(kin, uint160(obj)), urn,  ONE);
+        vat.slip(ilkName(kin, obj), urn,  ONE);
     }
 
     function exit(bytes32 urn, address guy, uint256 obj) external note {
-        require(obj <= MAX_UINT160);
+        require(uint256(uint160(obj)) == obj);
         require(bytes20(urn) == bytes20(msg.sender));
 
         gem.transferFrom(address(this), guy, obj);
-        vat.slip(ilkName(kin, uint160(obj)), urn, -ONE);
+        vat.slip(ilkName(kin, obj), urn, -ONE);
     }
 
-    function ilkName(bytes12 kin, uint160 obj) internal pure returns (bytes32 ilk) {
-        ilk = bytes32(uint256(bytes32(kin)) + uint256(obj));
+    // the ilk name is the concatenation of 12 bytes of kin + 20 bytes of obj
+    function ilkName(bytes12 kin, uint256 obj) internal pure returns (bytes32 ilk) {
+        ilk = bytes32(uint256(bytes32(kin)) + uint256(uint160(obj)));
     }
 }
 

--- a/src/NFTAdapter.sol
+++ b/src/NFTAdapter.sol
@@ -49,7 +49,8 @@ contract NFTAdapter is DSNote {
     bytes12 public kin;
     GemLike public gem;
 
-    int256 constant ONE = 10 ** 45;
+    int256  constant ONE = 10 ** 45;
+    uint160 constant MAX_UINT160 = 2^160 - 1;
 
     constructor(address vat_, bytes12 kin_, address gem_) public {
         vat = VatLike(vat_);
@@ -57,18 +58,20 @@ contract NFTAdapter is DSNote {
         gem = GemLike(gem_);
     }
 
-    function join(bytes32 urn, uint160 obj) external note {
+    function join(bytes32 urn, uint256 obj) external note {
+        require(obj <= MAX_UINT160);
         require(bytes20(urn) == bytes20(msg.sender));
 
         gem.transferFrom(msg.sender, address(this), obj);
-        vat.slip(ilkName(kin, obj), urn,  ONE);
+        vat.slip(ilkName(kin, uint160(obj)), urn,  ONE);
     }
 
-    function exit(bytes32 urn, address guy, uint160 obj) external note {
+    function exit(bytes32 urn, address guy, uint256 obj) external note {
+        require(obj <= MAX_UINT160);
         require(bytes20(urn) == bytes20(msg.sender));
 
         gem.transferFrom(address(this), guy, obj);
-        vat.slip(ilkName(kin, obj), urn, -ONE);
+        vat.slip(ilkName(kin, uint160(obj)), urn, -ONE);
     }
 
     function ilkName(bytes12 kin, uint160 obj) internal pure returns (bytes32 ilk) {

--- a/src/NFTAdapter.t.sol
+++ b/src/NFTAdapter.t.sol
@@ -32,15 +32,15 @@ contract TestUser {
         ptr = ptr_;
     }
 
-    function approve(address to, uint160 tokenId) public {
+    function approve(address to, uint256 tokenId) public {
         nft.approve(to, tokenId);
     }
 
-    function join(uint160 tokenId) public {
+    function join(uint256 tokenId) public {
         ptr.join(bytes32(bytes20(address(this))), tokenId);
     }
 
-    function exit(uint160 tokenId, address pal) public {
+    function exit(uint256 tokenId, address pal) public {
         ptr.exit(bytes32(bytes20(address(this))), pal, tokenId);
     }
 
@@ -61,11 +61,11 @@ contract NFTAdapterTest is DSTest {
 
     bytes12 constant kin     = "fnord";
     uint256 constant ONE     = 10 ** 45;
-    uint160 constant tokenId = 42;
+    uint256 constant tokenId = 42;
 
     function setUp() public {
         vat = new Vat();
-        ilk = ilkName(kin, tokenId);
+        ilk = ilkName(kin, uint160(tokenId));
         nft = new ERC721Mintable();
         gem = GemLike(address(nft));
         ptr = new NFTAdapter(address(vat), kin, address(gem));

--- a/src/NFTAdapter.t.sol
+++ b/src/NFTAdapter.t.sol
@@ -108,7 +108,7 @@ contract NFTAdapterTest is DSTest {
 
     // NOTE: Ideally we would inherit this from NFTAdapter, but we can't due to
     // a bug in hevm around `library` contracts and inheritance.
-    function ilkName(bytes12 kin, uint160 obj) internal pure returns (bytes32 ilk) {
-        ilk = bytes32(uint256(bytes32(kin)) + uint256(obj));
+    function ilkName(bytes12 kin, uint256 obj) internal pure returns (bytes32 ilk) {
+        ilk = bytes32(uint256(bytes32(kin)) + uint256(uint160(obj)));
     }
 }


### PR DESCRIPTION
This way, the adapter is compatible with [`dss-proxy-actions`][0] and the CDP
manager's [exit function][1].

[0]:
https://github.com/makerdao/dss-proxy-actions/blob/fca377c767a6fa6fc888d473b2a09859c5de9fdb/src/DssProxyActions.sol#L50
[1]:
https://github.com/makerdao/dss-cdp-manager/blob/c23c9fd3befead87b00038c8ca271257ce4609f7/src/DssCdpManager.sol#L105